### PR TITLE
Fix post selector persistence and add debug logs

### DIFF
--- a/gn-custom-post-selector.php
+++ b/gn-custom-post-selector.php
@@ -3,7 +3,7 @@
 Plugin Name: Gn Custom Post Selector
 Plugin URI:  https://www.georgenicolaou.me/plugins/gn-custom-post-selector
 Description: A Divi Builder Module that allows a user to add a title and select the post from any post type to dosplay as a list 
-Version:     1.0.2
+Version:     1.0.3
 Author:      George Nicolaou
 Author URI:  httgps://www.georgenicolaou.me
 License:     GPL2

--- a/includes/GnCustomPostSelector.php
+++ b/includes/GnCustomPostSelector.php
@@ -27,7 +27,7 @@ class GNWEBDEVCY_GnCustomPostSelector extends DiviExtension {
 	 *
 	 * @var string
 	 */
-       public $version = '1.0.2';
+       public $version = '1.0.3';
 
 	/**
 	 * GNWEBDEVCY_GnCustomPostSelector constructor.

--- a/includes/modules/CustomGNPostSelector/CustomGNPostSelector.jsx
+++ b/includes/modules/CustomGNPostSelector/CustomGNPostSelector.jsx
@@ -8,6 +8,18 @@ import './style.css';
 class CustomGNPostSelector extends Component {
   static slug = 'gnwebdevcy_custom_gn_post_selector';
 
+  componentDidMount() {
+    if (window && window.console) {
+      console.debug('GN Custom Post Selector mounted', this.props);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (window && window.console) {
+      console.debug('GN Custom Post Selector updated', { prevProps, currentProps: this.props });
+    }
+  }
+
   render() {
     const {title, posts: selectedPosts } = this.props;
 

--- a/includes/modules/CustomGNPostSelector/CustomGNPostSelector.php
+++ b/includes/modules/CustomGNPostSelector/CustomGNPostSelector.php
@@ -14,8 +14,10 @@ class GNWEBDEVCY_CustomGNPostSelector extends ET_Builder_Module {
 		$this->name = esc_html__( 'GN Custom Post Selector', 'gnwebdevcy-gn-custom-post-selector' );
 	}
 
-	public function get_fields() {
-		return array(
+        public function get_fields() {
+                $current_post_type = isset( $this->props['post_type'] ) ? $this->props['post_type'] : 'post';
+
+                return array(
 			'title' => array(
 				'label'           => esc_html__( 'Title', 'gnwebdevcy-gn-custom-post-selector' ),
 				'type'            => 'text',
@@ -31,14 +33,14 @@ class GNWEBDEVCY_CustomGNPostSelector extends ET_Builder_Module {
 				'description'     => esc_html__( 'Select the post type.', 'gnwebdevcy-gn-custom-post-selector' ),
 				'toggle_slug'     => 'main_content',
 			),
-			'posts' => array(
-				'label'           => esc_html__( 'Posts', 'gnwebdevcy-gn-custom-post-selector' ),
-				'type'            => 'multiple_checkboxes',
-				'options'         => $this->get_posts_options(),
-				'option_category' => 'basic_option',
-				'description'     => esc_html__( 'Select posts to display.', 'gnwebdevcy-gn-custom-post-selector' ),
-				'toggle_slug'     => 'main_content',
-			),
+                        'posts' => array(
+                                'label'           => esc_html__( 'Posts', 'gnwebdevcy-gn-custom-post-selector' ),
+                                'type'            => 'multiple_checkboxes',
+                                'options'         => $this->get_posts_options( $current_post_type ),
+                                'option_category' => 'basic_option',
+                                'description'     => esc_html__( 'Select posts to display.', 'gnwebdevcy-gn-custom-post-selector' ),
+                                'toggle_slug'     => 'main_content',
+                        ),
 		);
 	}
 


### PR DESCRIPTION
## Summary
- ensure post selections persist by loading options for the saved post type
- add console debug messages for easier troubleshooting
- bump plugin version to 1.0.3

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: divi-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d30e3127c8327b955431660d72a5d