### PR TITLE
Fix builder issue and bump version

### DIFF
--- a/gn-custom-post-selector.php
+++ b/gn-custom-post-selector.php
@@ -3,7 +3,7 @@
 Plugin Name: Gn Custom Post Selector
 Plugin URI:  https://www.georgenicolaou.me/plugins/gn-custom-post-selector
 Description: A Divi Builder Module that allows a user to add a title and select the post from any post type to dosplay as a list 
-Version:     1.0.3
+Version:     1.0.4
 Author:      George Nicolaou
 Author URI:  httgps://www.georgenicolaou.me
 License:     GPL2

--- a/includes/GnCustomPostSelector.php
+++ b/includes/GnCustomPostSelector.php
@@ -27,7 +27,7 @@ class GNWEBDEVCY_GnCustomPostSelector extends DiviExtension {
 	 *
 	 * @var string
 	 */
-       public $version = '1.0.3';
+       public $version = '1.0.4';
 
 	/**
 	 * GNWEBDEVCY_GnCustomPostSelector constructor.

--- a/includes/modules/CustomGNPostSelector/CustomGNPostSelector.php
+++ b/includes/modules/CustomGNPostSelector/CustomGNPostSelector.php
@@ -2,7 +2,7 @@
 
 class GNWEBDEVCY_CustomGNPostSelector extends ET_Builder_Module {
 	public $slug       = 'gnwebdevcy_custom_gn_post_selector';
-	public $vb_support = 'on';
+       public $vb_support = 'off';
 
 	protected $module_credits = array(
 		'module_uri' => 'https://www.georgenicolaou.me/plugins/gn-custom-post-selector',


### PR DESCRIPTION
## Summary
- disable visual builder JS support to avoid raw function output
- bump plugin version to 1.0.4

## Testing
- `php -l gn-custom-post-selector.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d34dff35083279ee2dfe0a60337c5