### PR TITLE
Update posts field dynamically with search

### DIFF
--- a/gn-custom-post-selector.php
+++ b/gn-custom-post-selector.php
@@ -3,7 +3,7 @@
 Plugin Name: Gn Custom Post Selector
 Plugin URI:  https://www.georgenicolaou.me/plugins/gn-custom-post-selector
 Description: A Divi Builder Module that allows a user to add a title and select the post from any post type to dosplay as a list 
-Version:     1.0.4
+Version:     1.0.5
 Author:      George Nicolaou
 Author URI:  httgps://www.georgenicolaou.me
 License:     GPL2
@@ -48,3 +48,23 @@ $gncps_update_checker = \YahnisElsts\PluginUpdateChecker\v5\PucFactory::buildUpd
        'gn-custom-post-selector'
 );
 $gncps_update_checker->setBranch( 'main' );
+add_action( 'wp_ajax_gncps_get_posts', 'gncps_get_posts' );
+add_action( 'wp_ajax_nopriv_gncps_get_posts', 'gncps_get_posts' );
+function gncps_get_posts() {
+    $post_type = isset( $_GET['post_type'] ) ? sanitize_text_field( $_GET['post_type'] ) : 'post';
+    $search    = isset( $_GET['search'] ) ? sanitize_text_field( $_GET['search'] ) : '';
+    $args = array(
+        'post_type'      => $post_type,
+        'posts_per_page' => 20,
+        's'              => $search,
+    );
+    $posts = get_posts( $args );
+    $options = array();
+    foreach ( $posts as $post ) {
+        $options[] = array(
+            'id'    => $post->ID,
+            'title' => $post->post_title,
+        );
+    }
+    wp_send_json_success( $options );
+}

--- a/includes/GnCustomPostSelector.php
+++ b/includes/GnCustomPostSelector.php
@@ -27,7 +27,7 @@ class GNWEBDEVCY_GnCustomPostSelector extends DiviExtension {
 	 *
 	 * @var string
 	 */
-       public $version = '1.0.4';
+       public $version = '1.0.5';
 
 	/**
 	 * GNWEBDEVCY_GnCustomPostSelector constructor.

--- a/includes/loader.js
+++ b/includes/loader.js
@@ -8,4 +8,50 @@ import fields from './fields';
 $(window).on('et_builder_api_ready', (event, API) => {
   API.registerModules(modules);
   API.registerModalFields(fields);
+
+  const fetchPosts = (postType, search, callback) => {
+    $.ajax({
+      url: window.ajaxurl,
+      method: 'GET',
+      data: {
+        action: 'gncps_get_posts',
+        post_type: postType,
+        search: search || ''
+      },
+      success: (resp) => {
+        if (resp.success) {
+          callback(resp.data);
+        }
+      }
+    });
+  };
+
+  const updatePosts = (modal) => {
+    const postType = modal.find('select[name$="post_type"]').val() || 'post';
+    const search = modal.find('.gncps-search-input').val() || '';
+    fetchPosts(postType, search, (posts) => {
+      const container = modal.find('[data-field-key="posts"] .et-pb-option-container');
+      if (!container.length) return;
+      const selected = {};
+      container.find('input:checked').each(function(){ selected[$(this).val()] = true; });
+      container.empty();
+      posts.forEach((p) => {
+        const checked = selected[p.id] ? ' checked="checked"' : '';
+        container.append(`<label class="et_pb_checkbox_label"><input type="checkbox" value="${p.id}"${checked}> ${p.title}</label>`);
+      });
+    });
+  };
+
+  $(document).on('et_builder_open_settings', (e, modal) => {
+    const $modal = $(modal);
+    const postsField = $modal.find('[data-field-key="posts"]');
+    if (!postsField.length) return;
+    if (!postsField.data('gncps-initialized')) {
+      postsField.data('gncps-initialized', true);
+      postsField.find('.et-pb-option-container').before('<input type="text" class="gncps-search-input" placeholder="Search posts..." style="margin-bottom:10px;width:100%;" />');
+      postsField.on('keyup', '.gncps-search-input', () => updatePosts($modal));
+      $modal.find('select[name$="post_type"]').on('change', () => updatePosts($modal));
+    }
+    updatePosts($modal);
+  });
 });


### PR DESCRIPTION
## Summary
- bump plugin version
- add ajax handler to fetch posts based on post type and search
- dynamically reload posts list in the builder and provide a search box

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d3acbb5a883279850ae14f7780bef