### PR TITLE
Implement browser debug logs and version bump

### DIFF
--- a/gn-custom-post-selector.php
+++ b/gn-custom-post-selector.php
@@ -3,7 +3,7 @@
 Plugin Name: Gn Custom Post Selector
 Plugin URI:  https://www.georgenicolaou.me/plugins/gn-custom-post-selector
 Description: A Divi Builder Module that allows a user to add a title and select the post from any post type to dosplay as a list 
-Version:     1.0.5
+Version:     1.0.6
 Author:      George Nicolaou
 Author URI:  httgps://www.georgenicolaou.me
 License:     GPL2

--- a/includes/GnCustomPostSelector.php
+++ b/includes/GnCustomPostSelector.php
@@ -27,7 +27,7 @@ class GNWEBDEVCY_GnCustomPostSelector extends DiviExtension {
 	 *
 	 * @var string
 	 */
-       public $version = '1.0.5';
+       public $version = '1.0.6';
 
 	/**
 	 * GNWEBDEVCY_GnCustomPostSelector constructor.

--- a/includes/modules/CustomGNPostSelector/CustomGNPostSelector.jsx
+++ b/includes/modules/CustomGNPostSelector/CustomGNPostSelector.jsx
@@ -8,29 +8,44 @@ import './style.css';
 class CustomGNPostSelector extends Component {
   static slug = 'gnwebdevcy_custom_gn_post_selector';
 
-  componentDidMount() {
+  constructor(props) {
+    super(props);
+    this.state = { logs: [] };
+  }
+
+  log(message, data) {
     if (window && window.console) {
-      console.debug('GN Custom Post Selector mounted', this.props);
+      console.debug(message, data);
     }
+    const entry = `${message} ${JSON.stringify(data)}`;
+    this.setState((state) => ({ logs: [...state.logs, entry] }));
+  }
+
+  componentDidMount() {
+    this.log('GN Custom Post Selector mounted', this.props);
   }
 
   componentDidUpdate(prevProps) {
-    if (window && window.console) {
-      console.debug('GN Custom Post Selector updated', { prevProps, currentProps: this.props });
-    }
+    this.log('GN Custom Post Selector updated', { prevProps, currentProps: this.props });
   }
 
   render() {
-    const {title, posts: selectedPosts } = this.props;
+    const { title, posts: selectedPosts } = this.props;
+    const { logs } = this.state;
 
     return (
       <div className="custom-gn-post-selector">
         {title && <h2>{title}</h2>}
         <ul>
-          {selectedPosts.split('|').map(postId => (
+          {selectedPosts.split('|').map((postId) => (
             <li key={postId}>{postId}</li> // Update this line to show post titles if available
           ))}
         </ul>
+        {logs.length > 0 && (
+          <pre className="gncps-debug">
+            {logs.join('\n')}
+          </pre>
+        )}
       </div>
     );
   }

--- a/includes/modules/CustomGNPostSelector/style.css
+++ b/includes/modules/CustomGNPostSelector/style.css
@@ -1,3 +1,12 @@
 .gnwebdevcy_hello_world {
 
 }
+
+.custom-gn-post-selector .gncps-debug {
+  margin-top: 10px;
+  padding: 10px;
+  background: #f9f9f9;
+  border: 1px dashed #ccc;
+  font-family: monospace;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- surface debug logs in the CustomGNPostSelector module UI
- style the debug output container
- bump plugin version to 1.0.6

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `npm test` *(fails: missing script)*
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686d3fbe89348327b7c7d84230536092