### PR TITLE
Fix post type update and bump version

### DIFF
--- a/gn-custom-post-selector.php
+++ b/gn-custom-post-selector.php
@@ -3,7 +3,7 @@
 Plugin Name: Gn Custom Post Selector
 Plugin URI:  https://www.georgenicolaou.me/plugins/gn-custom-post-selector
 Description: A Divi Builder Module that allows a user to add a title and select the post from any post type to dosplay as a list 
-Version:     1.0.6
+Version:     1.0.7
 Author:      George Nicolaou
 Author URI:  httgps://www.georgenicolaou.me
 License:     GPL2

--- a/includes/GnCustomPostSelector.php
+++ b/includes/GnCustomPostSelector.php
@@ -27,7 +27,7 @@ class GNWEBDEVCY_GnCustomPostSelector extends DiviExtension {
 	 *
 	 * @var string
 	 */
-       public $version = '1.0.6';
+       public $version = '1.0.7';
 
 	/**
 	 * GNWEBDEVCY_GnCustomPostSelector constructor.

--- a/includes/loader.js
+++ b/includes/loader.js
@@ -27,18 +27,35 @@ $(window).on('et_builder_api_ready', (event, API) => {
   };
 
   const updatePosts = (modal) => {
-    const postType = modal.find('select[name$="post_type"]').val() || 'post';
-    const search = modal.find('.gncps-search-input').val() || '';
-    fetchPosts(postType, search, (posts) => {
-      const container = modal.find('[data-field-key="posts"] .et-pb-option-container');
-      if (!container.length) return;
-      const selected = {};
+    const postType   = modal.find('select[name$="post_type"]').val() || 'post';
+    const search     = modal.find('.gncps-search-input').val() || '';
+    const postsField = modal.find('[data-field-key="posts"]');
+    const container  = postsField.find('.et-pb-option-container');
+    if (!container.length) return;
+
+    // Determine input name so Divi can save the selections correctly
+    let inputName = postsField.data('input-name');
+    if (!inputName) {
+      inputName = container.find('input[type="checkbox"]').first().attr('name') || '';
+      postsField.data('input-name', inputName);
+    }
+
+    // If post type changed clear previous selections
+    const prevType = postsField.data('prev-post-type');
+    const selected = {};
+    if (prevType === postType) {
       container.find('input:checked').each(function(){ selected[$(this).val()] = true; });
+    } else {
+      postsField.data('prev-post-type', postType);
+    }
+
+    fetchPosts(postType, search, (posts) => {
       container.empty();
       posts.forEach((p) => {
         const checked = selected[p.id] ? ' checked="checked"' : '';
-        container.append(`<label class="et_pb_checkbox_label"><input type="checkbox" value="${p.id}"${checked}> ${p.title}</label>`);
+        container.append(`<label class="et_pb_checkbox_label"><input type="checkbox" name="${inputName}" value="${p.id}"${checked}> ${p.title}</label>`);
       });
+      container.find('input').trigger('change');
     });
   };
 


### PR DESCRIPTION
## Summary
- refresh posts list when post type changes by keeping input name and clearing selections
- bump plugin version to 1.0.7

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686e2487e5d8832795783d023bf3c585