### PR TITLE
Fix dynamic post type refresh

### DIFF
--- a/gn-custom-post-selector.php
+++ b/gn-custom-post-selector.php
@@ -2,8 +2,8 @@
 /*
 Plugin Name: Gn Custom Post Selector
 Plugin URI:  https://www.georgenicolaou.me/plugins/gn-custom-post-selector
-Description: A Divi Builder Module that allows a user to add a title and select the post from any post type to dosplay as a list 
-Version:     1.0.7
+Description: A Divi Builder Module that allows a user to add a title and select the post from any post type to dosplay as a list
+Version:     1.0.8
 Author:      George Nicolaou
 Author URI:  httgps://www.georgenicolaou.me
 License:     GPL2
@@ -48,6 +48,18 @@ $gncps_update_checker = \YahnisElsts\PluginUpdateChecker\v5\PucFactory::buildUpd
        'gn-custom-post-selector'
 );
 $gncps_update_checker->setBranch( 'main' );
+
+function gncps_enqueue_builder_assets() {
+    wp_enqueue_script(
+        'gncps-admin',
+        plugin_dir_url( __FILE__ ) . 'scripts/admin.js',
+        array( 'jquery' ),
+        '1.0.8',
+        true
+    );
+}
+add_action( 'admin_enqueue_scripts', 'gncps_enqueue_builder_assets' );
+add_action( 'wp_enqueue_scripts', 'gncps_enqueue_builder_assets' );
 add_action( 'wp_ajax_gncps_get_posts', 'gncps_get_posts' );
 add_action( 'wp_ajax_nopriv_gncps_get_posts', 'gncps_get_posts' );
 function gncps_get_posts() {

--- a/includes/GnCustomPostSelector.php
+++ b/includes/GnCustomPostSelector.php
@@ -27,7 +27,7 @@ class GNWEBDEVCY_GnCustomPostSelector extends DiviExtension {
 	 *
 	 * @var string
 	 */
-       public $version = '1.0.7';
+       public $version = '1.0.8';
 
 	/**
 	 * GNWEBDEVCY_GnCustomPostSelector constructor.

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -1,0 +1,58 @@
+(function($){
+  function fetchPosts(postType, search, cb){
+    $.get(ajaxurl, {
+      action: 'gncps_get_posts',
+      post_type: postType,
+      search: search || ''
+    }, function(resp){
+      if(resp && resp.success && typeof cb === 'function'){
+        cb(resp.data);
+      }
+    });
+  }
+
+  function updatePosts($modal){
+    var postType   = $modal.find('select[name$="post_type"]').val() || 'post';
+    var search     = $modal.find('.gncps-search-input').val() || '';
+    var postsField = $modal.find('[data-field-key="posts"]');
+    var container  = postsField.find('.et-pb-option-container');
+    if(!container.length) return;
+
+    var inputName = postsField.data('input-name');
+    if(!inputName){
+      inputName = container.find('input[type="checkbox"]').first().attr('name') || '';
+      postsField.data('input-name', inputName);
+    }
+
+    var prevType = postsField.data('prev-post-type');
+    var selected = {};
+    if(prevType === postType){
+      container.find('input:checked').each(function(){ selected[$(this).val()] = true; });
+    } else {
+      postsField.data('prev-post-type', postType);
+    }
+
+    fetchPosts(postType, search, function(posts){
+      container.empty();
+      $.each(posts, function(i, p){
+        var checked = selected[p.id] ? ' checked="checked"' : '';
+        container.append('<label class="et_pb_checkbox_label"><input type="checkbox" name="'+inputName+'" value="'+p.id+'"'+checked+'> '+p.title+'</label>');
+      });
+      container.find('input').trigger('change');
+    });
+  }
+
+  $(document).on('et_builder_open_settings', function(e, modal){
+    var $modal = $(modal);
+    var postsField = $modal.find('[data-field-key="posts"]');
+    if(!postsField.length) return;
+    if(!postsField.data('gncps-initialized')){
+      postsField.data('gncps-initialized', true);
+      postsField.find('.et-pb-option-container').before('<input type="text" class="gncps-search-input" placeholder="Search posts..." style="margin-bottom:10px;width:100%;" />');
+      postsField.on('keyup', '.gncps-search-input', function(){ updatePosts($modal); });
+      $modal.find('select[name$="post_type"]').on('change', function(){ updatePosts($modal); });
+    }
+    updatePosts($modal);
+  });
+})(jQuery);
+


### PR DESCRIPTION
## Summary
- add WordPress admin script for refreshing posts when changing post type
- enqueue new script
- bump plugin version to 1.0.8

## Testing
- `npm run build` *(fails: `divi-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e2a4a6fb48327ab9faac2aefa403b