### PR TITLE
Add build automation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /styles/style-dbp.min.css
 /styles/style.min.css
 asset-manifest.json
+/*.zip
 *.map
 
 # misc

--- a/README.md
+++ b/README.md
@@ -670,3 +670,11 @@ If you have ideas for more “How To” recipes that should be on this page, [le
 ## Automatic Updates
 
 This plugin uses the [Plugin Update Checker](https://github.com/YahnisElsts/plugin-update-checker) library to receive updates directly from its GitHub repository.
+
+## Building the Module
+
+To compile the extension and generate a release archive, run the `build.sh` script from the project root. This script installs dependencies, builds the optimized bundles and creates `gn-custom-post-selector.zip`.
+
+```bash
+./build.sh
+```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and package the GN Custom Post Selector plugin.
+# Ensure Node.js 14 is available using nvm if present.
+if command -v nvm >/dev/null 2>&1; then
+  nvm install 14 >/dev/null
+  nvm use 14 >/dev/null
+fi
+
+npm install
+npm run build
+npm run zip
+
+echo "Build complete. Output: gn-custom-post-selector.zip"
+


### PR DESCRIPTION
## Summary
- add `build.sh` to automate installing dependencies and building the plugin
- ignore generated zip files
- document the new build script in `README.md`

## Testing
- `npm install`
- `npm run build`
- `npm run zip`


------
https://chatgpt.com/codex/tasks/task_e_686e3f948a908327800debe6aef37902