### PR TITLE
Improve dynamic post selection

### DIFF
--- a/gn-custom-post-selector.php
+++ b/gn-custom-post-selector.php
@@ -3,7 +3,7 @@
 Plugin Name: Gn Custom Post Selector
 Plugin URI:  https://www.georgenicolaou.me/plugins/gn-custom-post-selector
 Description: A Divi Builder Module that allows a user to add a title and select the post from any post type to dosplay as a list
-Version:     1.0.8
+Version:     1.0.9
 Author:      George Nicolaou
 Author URI:  httgps://www.georgenicolaou.me
 License:     GPL2
@@ -54,7 +54,7 @@ function gncps_enqueue_builder_assets() {
         'gncps-admin',
         plugin_dir_url( __FILE__ ) . 'scripts/admin.js',
         array( 'jquery' ),
-        '1.0.8',
+        '1.0.9',
         true
     );
 }

--- a/includes/GnCustomPostSelector.php
+++ b/includes/GnCustomPostSelector.php
@@ -27,7 +27,7 @@ class GNWEBDEVCY_GnCustomPostSelector extends DiviExtension {
 	 *
 	 * @var string
 	 */
-       public $version = '1.0.8';
+       public $version = '1.0.9';
 
 	/**
 	 * GNWEBDEVCY_GnCustomPostSelector constructor.


### PR DESCRIPTION
## Summary
- refresh posts list when post type changes
- dynamically populate posts list with safe string keys
- parse selected values back to post IDs on render
- bump plugin version to 1.0.9

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e482d2180832782f43d37406790b6